### PR TITLE
Adds runtime type checks for maxmin cpp wrappers

### DIFF
--- a/src/veccs/orderings.py
+++ b/src/veccs/orderings.py
@@ -151,6 +151,9 @@ def maxmin_cpp(locs: np.ndarray) -> np.ndarray:
 
     """
 
+    if not isinstance(locs, np.ndarray):
+        raise TypeError("locs must be a numpy array")
+
     idx = _maxmin_cpp(locs)
     return np.array(idx)
 
@@ -253,6 +256,13 @@ def maxmin_pred_cpp(locs: np.ndarray, pred_locs: np.ndarray) -> np.ndarray:
     .. [1] https://github.com/katzfuss-group/variationalVecchia/blob/
            4ce03ddb53f3006b5cd1d1e3fe0268744e408039/external/maxmin_cpp/maxMin.cpp
     """
+
+    if not isinstance(locs, np.ndarray):
+        raise TypeError("locs must be a numpy array")
+
+    if not isinstance(pred_locs, np.ndarray):
+        raise TypeError("pred_locs must be a numpy array")
+
     locs_all = np.concatenate((locs, pred_locs), axis=0)
     npred = pred_locs.shape[0]
 
@@ -314,6 +324,13 @@ def maxmin_cpp_ancestor(
     .. [1] https://github.com/katzfuss-group/variationalVecchia/blob/
            4ce03ddb53f3006b5cd1d1e3fe0268744e408039/external/maxmin_cpp/maxMin.cpp
     """
+
+    if not isinstance(locs, np.ndarray):
+        raise TypeError("locs must be a numpy array")
+
+    if not isinstance(pred_locs, np.ndarray):
+        raise TypeError("pred_locs must be a numpy array")
+
     locs_all = np.concatenate((locs, pred_locs), axis=0)
     npred = pred_locs.shape[0]
 

--- a/tests/test_orderings.py
+++ b/tests/test_orderings.py
@@ -1,3 +1,5 @@
+import typing
+
 import numpy as np
 import pytest
 import scipy.spatial.distance
@@ -112,3 +114,26 @@ def test_maxmin_cpp_ancestor(locations_2d):
     correct_order = np.array([0, 4, 3, 2, 1, 5, 6, 7, 8, 9])
     assert np.all(correct_order == ord)
     assert np.all(ret_obj.sparsity == ret_obj.ancestor_set_reduced)
+
+
+@typing.no_type_check
+def test_typechecks_cpp() -> None:
+    """
+    Test type checks for the numpy arguments in the cpp function wrappers.
+
+    Type checks are disabled for this function to test the runtime type checks.
+    """
+    with pytest.raises(TypeError):
+        maxmin_cpp(1.0)
+
+    with pytest.raises(TypeError):
+        maxmin_pred_cpp(1.0, np.array([[1.0]]))
+
+    with pytest.raises(TypeError):
+        maxmin_pred_cpp(np.array([[1.0]]), 1.0)
+
+    with pytest.raises(TypeError):
+        maxmin_cpp_ancestor(1.0, np.array([[1.0]]), 1.005)
+
+    with pytest.raises(TypeError):
+        maxmin_cpp_ancestor(np.array([[1.0]]), 1.0, 1.005)


### PR DESCRIPTION
Adds runtime type checks for maxmin cpp wrapper functions

- `orderings.maxmin_cpp`
- `orderings.maxmin_pred_cpp`
- `maxmin_cpp_ancestor`

to address issue #4.